### PR TITLE
Add CITATION.cff for citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,36 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite both the software and the associated preprint."
+title: "MouseMapper: Whole-body deep-learning image analysis for systemic disease phenotyping"
+abstract: >-
+  MouseMapper is a suite of deep-learning image analysis modules
+  (Nerve, Immune, Tissue, and Graph modules) integrated with tissue
+  clearing and light-sheet microscopy, enabling quantitative analysis
+  of cellular and structural changes across the entire mouse body.
+type: software
+authors:
+  - family-names: "Ertürk"
+    given-names: "Ali"
+    orcid: "https://orcid.org/0000-0003-4310-1738"
+repository-code: "https://github.com/erturklab/mouseMapper"
+url: "https://github.com/erturklab/mouseMapper"
+license-url: "https://github.com/erturklab/mouseMapper/blob/main/LICENSE"
+keywords:
+  - "deep learning"
+  - "light-sheet microscopy"
+  - "tissue clearing"
+  - "whole-body imaging"
+  - "obesity"
+  - "nerve segmentation"
+  - "immune cell quantification"
+  - "nnU-Net"
+  - "vessel graph extraction"
+preferred-citation:
+  type: article
+  title: "Deep Learning and 3D Imaging Reveal Whole-Body Alterations in Obesity"
+  authors:
+    - family-names: "Ertürk"
+      given-names: "Ali"
+  doi: "10.1101/2024.08.18.608300"
+  url: "https://doi.org/10.1101/2024.08.18.608300"
+  journal: "bioRxiv"
+  year: 2024


### PR DESCRIPTION
## What
Adds a `CITATION.cff` file (Citation File Format v1.2.0) so that the repository can be cited via GitHub's built-in "Cite this repository" feature.

## Why
- One-click citation export in **APA / BibTeX / RIS** for users referencing MouseMapper in papers
- Recognized automatically by **GitHub, Zenodo, Zotero, Mendeley** and most reference managers
- Pure metadata — **no code or behavior changes**
- Follows the official [Citation File Format spec](https://citation-file-format.github.io/)

## What it looks like
After merge, a **"Cite this repository"** entry will appear in the right sidebar of the repo, opening a popup with ready-to-copy APA and BibTeX citations pointing to the bioRxiv preprint (DOI: `10.1101/2024.08.18.608300`).

I verified this on my fork — the button renders correctly and produces valid output.

## Notes for the maintainer
A few intentional choices that you may want to refine before merging:

- **Author list is minimal** (only Ali Ertürk for now). Please amend with the full author list from the preprint.
- **`year: 2024`** is taken from the bioRxiv submission date encoded in the DOI prefix. Please update if a newer revision exists.
- Once the paper is **published in a peer-reviewed journal**, the `preferred-citation` block can be updated with the final journal name, volume, pages, and DOI.

Happy to amend any of the above in this PR if you share the details — or feel free to edit directly (I left "Allow edits by maintainers" enabled).

Thanks for the great work on MouseMapper! 🐭