### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+<!--
+Thanks for opening a pull request for mouseMapper! 🐭🗺️
+Please fill in the sections below to help maintainers review your change quickly.
+Feel free to delete sections that do not apply.
+-->
+
+## Summary
+
+<!-- One or two sentences: what does this PR do, and why? -->
+
+## Type of change
+
+<!-- Mark with an "x" all that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would change existing behaviour)
+- [ ] Documentation update
+- [ ] Refactor / code clean-up (no behavioural change)
+- [ ] CI / tooling / repository housekeeping
+- [ ] Other (please describe):
+
+## Related issues
+
+<!-- Link any related issues, e.g. "Closes #123" or "Refs #456". -->
+
+## How has this been tested?
+
+<!--
+Describe the steps you took to verify the change. For example:
+- Ran the affected script on the example data in `*/example_data/`
+- Reproduced the bug before the fix, confirmed it is gone after
+- Added or updated tests
+-->
+
+## Checklist
+
+- [ ] I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [ ] My change focuses on a single, reviewable topic
+- [ ] I have updated the relevant module's `README.MD` if behaviour changed
+- [ ] I have not committed large data files, model weights, or other binaries
+- [ ] I have not introduced new credentials, tokens, or private endpoints
+- [ ] For security-sensitive issues I used the private channel in [`SECURITY.md`](./SECURITY.md) instead of a public PR
+
+## Additional notes
+
+<!-- Screenshots, benchmarks, follow-up work, or anything else maintainers should know. -->


### PR DESCRIPTION
## What
Adds `.github/pull_request_template.md`. Once merged, every new pull request opened against this repo will be pre-populated with a short, opinionated checklist.

## Why
- Helps contributors structure their PRs so maintainers can review faster.
- Surfaces a few things that are easy to forget but painful to clean up afterwards: large binaries, secrets, README updates after a behavioural change.
- Quietly directs contributors to `CODE_OF_CONDUCT.md` and `SECURITY.md` at the moment they are most relevant.

## What's in the template
- **Summary** — one or two sentences.
- **Type of change** — checkbox list (bug fix, feature, breaking, docs, refactor, CI/housekeeping, other).
- **Related issues** — `Closes #…` style links.
- **How has this been tested?** — encourages mentioning runs on `example_data/`.
- **Checklist** — Code of Conduct, single topic, README update, no binaries, no secrets, security path.
- **Additional notes** — escape hatch for screenshots / benchmarks.

## Notes for the maintainer
- Docs/config only; no code touched.
- Every section is optional — the template tells contributors they can delete sections that don't apply, so it stays lightweight.
- This PR itself was opened before the template existed in `main`, so it does not show the new checklist (GitHub only applies templates that are already on the base branch).